### PR TITLE
Release 5.0.0-rc1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Exclude files copied from 'common/'
+!apache/Dockerfile
+!fpm/Dockerfile
+apache/*
+fpm/*

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -33,8 +33,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 VOLUME /var/www/html
 
 # Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 2.16.2
-ENV MAUTIC_SHA1 df6735df8d7d31cc6bc505c38ee8147b40b8311b
+ENV MAUTIC_VERSION 5.0.0-rc1
+ENV MAUTIC_SHA1 6e80bf686e3997721b9d5232aadd03a8f0dc47cd
 
 # By default enable cron jobs
 ENV MAUTIC_RUN_CRON_JOBS true

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -33,8 +33,8 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 VOLUME /var/www/html
 
 # Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 2.16.2
-ENV MAUTIC_SHA1 df6735df8d7d31cc6bc505c38ee8147b40b8311b
+ENV MAUTIC_VERSION 5.0.0-rc1
+ENV MAUTIC_SHA1 6e80bf686e3997721b9d5232aadd03a8f0dc47cd
 
 # By default enable cron jobs
 ENV MAUTIC_RUN_CRON_JOBS true


### PR DESCRIPTION
- Bump Mautic version from 2.16.2 to 5.0.0-rc1
- Ignore files copied from 'common/'