### PR TITLE
Bump to Php 7.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Build ${{ matrix.image }} image
         uses: docker/build-push-action@v2
         with:
-          context: ${{ matrix.image }}
+          file: ${{ matrix.image }}/Dockerfile
           push: false
-          tags: mautic/docker-${{ matrix.image }}:latest
+          tags: redtux/mautic-${{ matrix.image }}:latest

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -13,7 +13,8 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
-FROM php:7.1-apache
+ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
+FROM "php:${PHP_VERSION}-apache"
 
 LABEL vendor="redgnus"
 LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)"

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -13,36 +13,103 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
+# Define PHP version and SHA256 hash
 ARG PHP_VERSION="${PHP_VERSION:-7.4.33}"
 ARG PHP_SHA256="${PHP_SHA256:-924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927}"
 FROM "php:${PHP_VERSION}-apache"
 
-LABEL vendor="redgnus"
-LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)"
-LABEL org.opencontainers.image.source="https://github.com/redtux/mautic"
+# Define Mautic version and SHA1 hash
+ENV MAUTIC_VERSION 4.4.10
+ENV MAUTIC_SHA1 8da80700b742d67dc7d952196adf0506b2ba0535
+
+# Set metadata labels
+LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)" \
+      org.opencontainers.image.description="Mautic ${MAUTIC_VERSION} · PHP ${PHP_VERSION} · Apache" \
+      org.opencontainers.image.source="https://github.com/redtux/mautic" \
+      vendor="redgnus"
+
+# Define environment variables
+ENV MAUTIC_RELEASE_URL=https://github.com/mautic/mautic/releases/download \
+    MAUTIC_RUN_CRON_JOBS=true \
+    MAUTIC_RUN_MIGRATIONS=false \
+    MAUTIC_DB_USER=root \
+    MAUTIC_DB_NAME=mautic \
+    MAUTIC_DB_PORT=3306 \
+    PHP_INI_DATE_TIMEZONE='UTC' \
+    PHP_MEMORY_LIMIT=512M \
+    PHP_MAX_UPLOAD=512M \
+    PHP_MAX_EXECUTION_TIME=300
+
+# Install system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    ca-certificates \
+    cron \
+    curl \
+    imagemagick \
+    graphicsmagick \
+    libaprutil1-dev \
+    libc-client-dev \
+    libcurl4-gnutls-dev \
+    libfreetype6-dev \
+    libgif-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libkrb5-dev \
+    libmagickwand-dev \
+    libmcrypt-dev \
+    libonig-dev \
+    libpng-dev \
+    libssl-dev \
+    libtiff-dev \
+    libwebp-dev \
+    libxpm-dev \
+    libxml2-dev \
+    libzip-dev \
+    sudo \
+    unzip \
+    wget \
+    zip \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm /etc/cron.daily/*
 
 # Install PHP extensions
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    cron \
-    git \
-    wget \
-    sudo \
-    libc-client-dev \
-    libicu-dev \
-    libkrb5-dev \
-    libmcrypt-dev \
-    libssl-dev \
-    libz-dev \
-    unzip \
-    zip \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm /etc/cron.daily/*
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install \
+        bcmath \
+        curl \
+        exif \
+        gd \
+        imap \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        sockets \
+        zip \
+    && docker-php-ext-enable \
+        bcmath \
+        curl \
+        exif \
+        gd \
+        imap \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        sockets \
+        zip
 
-RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos \
-    && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath\
-    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath
+# Copy necessary files
+COPY docker-entrypoint.sh /entrypoint.sh
+COPY makeconfig.php /makeconfig.php
+COPY makedb.php /makedb.php
+COPY mautic.crontab /etc/cron.d/mautic
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
@@ -50,43 +117,21 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 # Define Mautic volume to persist data
 VOLUME /var/www/html
 
-# Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 4.4.10
-ENV MAUTIC_SHA1 8da80700b742d67dc7d952196adf0506b2ba0535
-
-# By default enable cron jobs
-ENV MAUTIC_RUN_CRON_JOBS true
-
-# Setting an root user for test
-ENV MAUTIC_DB_USER root
-ENV MAUTIC_DB_NAME mautic
-
-# Setting PHP properties
-ENV PHP_INI_DATE_TIMEZONE='UTC' \
-    PHP_MEMORY_LIMIT=512M \
-    PHP_MAX_UPLOAD=128M \
-    PHP_MAX_EXECUTION_TIME=300
-
-# Download package and extract to web volume
-RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
+# Download Mautic package and extract to web volume
+RUN curl -o mautic.zip -SL "${MAUTIC_RELEASE_URL}/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip" \
     && echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \
     && mkdir /usr/src/mautic \
     && unzip mautic.zip -d /usr/src/mautic \
     && rm mautic.zip \
     && chown -R www-data:www-data /usr/src/mautic
 
-# Copy init scripts and custom .htaccess
-COPY docker-entrypoint.sh /entrypoint.sh
-COPY makeconfig.php /makeconfig.php
-COPY makedb.php /makedb.php
-COPY mautic.crontab /etc/cron.d/mautic
-RUN chmod 644 /etc/cron.d/mautic
+# Set file permissions
+RUN chmod 644 /etc/cron.d/mautic \
+ && chmod 755 /entrypoint.sh
 
-# Enable Apache Rewrite Module
+# Enable the Apache rewrite module
 RUN a2enmod rewrite
 
-# Apply necessary permissions
-RUN ["chmod", "+x", "/entrypoint.sh"]
+# Define entrypoint and command
 ENTRYPOINT ["/entrypoint.sh"]
-
 CMD ["apache2-foreground"]

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -14,6 +14,7 @@
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
 ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
+ARG PHP_SHA256="${PHP_SHA256:-bd7c0a9bd5433289ee01fd440af3715309faf583f75832b64fe169c100d52968}"
 FROM "php:${PHP_VERSION}-apache"
 
 LABEL vendor="redgnus"

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -13,8 +13,8 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
-ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
-ARG PHP_SHA256="${PHP_SHA256:-bd7c0a9bd5433289ee01fd440af3715309faf583f75832b64fe169c100d52968}"
+ARG PHP_VERSION="${PHP_VERSION:-7.4.33}"
+ARG PHP_SHA256="${PHP_SHA256:-924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927}"
 FROM "php:${PHP_VERSION}-apache"
 
 LABEL vendor="redgnus"

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -5,6 +5,7 @@ if [ ! -f /usr/local/etc/php/php.ini ]; then
 	cat <<EOF > /usr/local/etc/php/php.ini
 date.timezone = "${PHP_INI_DATE_TIMEZONE}"
 always_populate_raw_post_data = -1
+zend.assertions = -1
 memory_limit = ${PHP_MEMORY_LIMIT}
 file_uploads = On
 upload_max_filesize = ${PHP_MAX_UPLOAD}
@@ -12,7 +13,6 @@ post_max_size = ${PHP_MAX_UPLOAD}
 max_execution_time = ${PHP_MAX_EXECUTION_TIME}
 EOF
 fi
-
 
 if [ -n "$MYSQL_PORT_3306_TCP" ]; then
         if [ -z "$MAUTIC_DB_HOST" ]; then
@@ -47,42 +47,42 @@ fi
 #ENABLES HUBSPOT CRON
 if [ -n "$MAUTIC_CRON_HUBSPOT" ]; then
         echo >&2 "CRON: Activating Hubspot"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:fetchleads --integration=Hubspot > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
-        echo "15,45 * * * *     www-data   php /var/www/html/app/console mautic:integration:pushactivity --integration=Hubspot > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:fetchleads --integration=Hubspot > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "15,45 * * * *     www-data   php /var/www/html/bin/console mautic:integration:pushactivity --integration=Hubspot > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 #ENABLES SALESFORCE CRON
 if [ -n "$MAUTIC_CRON_SALESFORCE" ]; then
         echo >&2 "CRON: Activating Salesforce"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:fetchleads --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
-        echo "12,42 * * * *     www-data   php /var/www/html/app/console mautic:integration:pushactivity --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
-        echo "14,44 * * * *     www-data   php /var/www/html/app/console mautic:integration:pushleadactivity --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
-        echo "16,46 * * * *     www-data   php /var/www/html/app/console mautic:integration:synccontacts --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:fetchleads --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "12,42 * * * *     www-data   php /var/www/html/bin/console mautic:integration:pushactivity --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "14,44 * * * *     www-data   php /var/www/html/bin/console mautic:integration:pushleadactivity --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "16,46 * * * *     www-data   php /var/www/html/bin/console mautic:integration:synccontacts --integration=Salesforce > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 #ENABLES SUGARCRM CRON
 if [ -n "$MAUTIC_CRON_SUGARCRM" ]; then
         echo >&2 "CRON: Activating SugarCRM"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:fetchleads --fetch-all --integration=Sugarcrm > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:fetchleads --fetch-all --integration=Sugarcrm > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 #ENABLES PIPEDRIVE CRON
 if [ -n "$MAUTIC_CRON_PIPEDRIVE" ]; then
         echo >&2 "CRON: Activating Pipedrive"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:pipedrive:fetch > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
-        echo "15,45 * * * *     www-data   php /var/www/html/app/console mautic:integration:pipedrive:push > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:pipedrive:fetch > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "15,45 * * * *     www-data   php /var/www/html/bin/console mautic:integration:pipedrive:push > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 #ENABLES ZOHO CRON
 if [ -n "$MAUTIC_CRON_ZOHO" ]; then
         echo >&2 "CRON: Activating ZohoCRM"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:fetchleads --integration=Zoho > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:fetchleads --integration=Zoho > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 #ENABLES DYNAMICS CRON
 if [ -n "$MAUTIC_CRON_DYNAMICS" ]; then
         echo >&2 "CRON: Activating DynamicsCRM"
-        echo "10,40 * * * *     www-data   php /var/www/html/app/console mautic:integration:fetchleads -i Dynamics > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
+        echo "10,40 * * * *     www-data   php /var/www/html/bin/console mautic:integration:fetchleads -i Dynamics > /var/log/cron.pipe 2>&1" >> /etc/cron.d/mautic
 fi
 
 if ! [ -e index.php -a -e app/AppKernel.php ]; then
@@ -102,47 +102,129 @@ fi
 php /makedb.php "$MAUTIC_DB_HOST" "$MAUTIC_DB_USER" "$MAUTIC_DB_PASSWORD" "$MAUTIC_DB_NAME"
 
 echo >&2 "========================================================================"
-echo >&2
 echo >&2 "This server is now configured to run Mautic!"
 echo >&2 "The following information will be prefilled into the installer (keep password field empty):"
 echo >&2 "Host Name: $MAUTIC_DB_HOST"
 echo >&2 "Database Name: $MAUTIC_DB_NAME"
 echo >&2 "Database Username: $MAUTIC_DB_USER"
 echo >&2 "Database Password: $MAUTIC_DB_PASSWORD"
+echo >&2 "========================================================================"
+echo >&2
+echo >&2
 
-# Write the database connection to the config so the installer prefills it
-if ! [ -e app/config/local.php ]; then
-        php /makeconfig.php
+# Write the provided configuration to the config so the installer prefills it
+echo >&2 "========================================================================"
+php /makeconfig.php
+echo >&2 "========================================================================"
+echo >&2
+echo >&2
 
-        # Make sure our web user owns the config file if it exists
-        chown www-data:www-data app/config/local.php
-        mkdir -p /var/www/html/app/logs
-        chown www-data:www-data /var/www/html/app/logs
+# Make sure our web user owns the config file
+chown www-data:www-data app/config/local.php
+
+# Make sure logs exists and is owned by www-data
+mkdir -p /var/www/html/app/logs
+chown -R www-data:www-data /var/www/html/app/logs
+
+# Make sure cache exists and is owned by www-data
+mkdir -p /var/www/html/var/cache/prod
+chown -R www-data:www-data /var/www/html/var/cache
+
+if ! grep -Fq "secret_key" /var/www/html/app/config/local.php; then
+  echo >&2 "========================================================================"
+  echo >&2 "Mautic not currently installed (no secret_key in local.php)"
+  echo >&2
+
+  if [ -n "$MAUTIC_URL" ] && [ -n "$MAUTIC_ADMIN_EMAIL" ] && [ -n "$MAUTIC_ADMIN_PASSWORD" ]; then
+
+    echo >&2 "URL & Admin credentials supplied, attempting automated mautic installation."
+    echo >&2
+
+    INSTALL_PARAMS=("$MAUTIC_URL")
+
+    if [ -n "$MAUTIC_INSTALL_FORCE" ]; then
+      INSTALL_PARAMS+=(-f)
+    else
+      if ! [[ $MAUTIC_URL =~ https://.* ]]; then
+        echo >&2 "URL not using HTTPS and MAUTIC_INSTALL_FORCE not provided.  please provide"
+        echo >&2 "a https url or set MAUTIC_INSTALL_FORCE true to continue."
+        echo >&2
+        echo >&2 "========================================================================"
+        sleep 5
+        exit 1
+      fi
+    fi
+
+    if [ -n "$MAUTIC_ADMIN_USERNAME" ]; then
+      INSTALL_PARAMS+=(--admin_username="$MAUTIC_ADMIN_USERNAME")
+    fi
+    if [ -n "$MAUTIC_ADMIN_FIRSTNAME" ]; then
+      INSTALL_PARAMS+=(--admin_firstname="$MAUTIC_ADMIN_FIRSTNAME")
+    fi
+    if [ -n "$MAUTIC_ADMIN_LASTNAME" ]; then
+      INSTALL_PARAMS+=(--admin_lastname="$MAUTIC_ADMIN_LASTNAME")
+    fi
+
+    sudo -Eu www-data php /var/www/html/bin/console mautic:install ${INSTALL_PARAMS[@]}
+  else
+    echo >&2 "URL & Admin credentials not supplied, please install mautic manually."
+  fi
+  echo >&2 "========================================================================"
+  echo >&2
+  echo >&2
+fi
+
+# clear mautic cache
+sudo -Eu www-data php /var/www/html/bin/console mautic:cache:clear
+
+if [[ "$MAUTIC_RUN_MIGRATIONS" == "true" ]]; then
+    echo >&2 "========================================================================"
+    echo >&2 "Applying any needed database migrations"
+    echo >&2
+    sudo -Eu www-data php /var/www/html/bin/console doctrine:migration:migrate -n
+    echo >&2 "========================================================================"
+    echo >&2
+    echo >&2
+fi
+
+# if we have the credentials to do a maxmind download
+if grep -Fq "'ip_lookup_auth' => '" /var/www/html/app/config/local.php; then
+  echo >&2 "========================================================================"
+  echo >&2 "Grabbing latest ip lookup database"
+  echo >&2
+  sudo -Eu www-data php /var/www/html/bin/console mautic:iplookup:download
+  echo >&2 "========================================================================"
+  echo >&2
+  echo >&2
 fi
 
 if [[ "$MAUTIC_RUN_CRON_JOBS" == "true" ]]; then
-    if [ ! -e /var/log/cron.pipe ]; then
-        mkfifo /var/log/cron.pipe
-        chown www-data:www-data /var/log/cron.pipe
-    fi
-    (tail -f /var/log/cron.pipe | while read line; do echo "[CRON] $line"; done) &
-    CRONLOGPID=$!
-    cron -f &
-    CRONPID=$!
+  echo >&2 "========================================================================"
+  echo >&2 "Activating cron"
+  if [ ! -e /var/log/cron.pipe ]; then
+      mkfifo /var/log/cron.pipe
+      chown www-data:www-data /var/log/cron.pipe
+  fi
+  (tail -f /var/log/cron.pipe | while read line; do echo "[CRON] $line"; done) &
+  CRONLOGPID=$!
+  cron -f &
+  CRONPID=$!
+  echo >&2 "========================================================================"
+  echo >&2
+  echo >&2
 else
-    echo >&2 "Not running cron as requested."
+  echo >&2 "========================================================================"
+  echo >&2 "Not running cron"
+  echo >&2 "========================================================================"
+  echo >&2
+  echo >&2
 fi
 
-echo >&2
 echo >&2 "========================================================================"
-
-
-# Github Pull Tester
-if [ -n "$MAUTIC_TESTER" ]; then
-  echo >&2 "Copying Mautic Github Pull Tester"
-  wget https://raw.githubusercontent.com/mautic/mautic-tester/master/tester.php
-fi
-
+echo >&2 "Starting mautic"
+echo >&2 "========================================================================"
+echo >&2
+echo >&2
 
 "$@" &
 MAINPID=$!

--- a/common/makeconfig.php
+++ b/common/makeconfig.php
@@ -1,12 +1,24 @@
 <?php
 $stderr = fopen('php://stderr', 'w');
 
-fwrite($stderr, "\nWriting initial Mautic config\n");
+$path     = '/var/www/html/app/config/local.php';
 
-$parameters = array(
-	'db_driver'      => 'pdo_mysql',
-	'install_source' => 'Docker'
-);
+// grab existing config if it exists
+if(file_exists($path)) {
+  fwrite($stderr, "Updating existing mautic config\n");
+  include($path);
+}
+else {
+  fwrite($stderr, "Creating new existing mautic config\n");
+}
+
+// if existing config is nonexistant or broken, create blank config
+if(is_null($parameters)) {
+	$parameters = array(
+		'db_driver'      => 'pdo_mysql',
+		'install_source' => 'Docker'
+	);
+}
 
 if(array_key_exists('MAUTIC_DB_HOST', $_ENV)) {
     // Figure out if we have a port in the database host string
@@ -16,6 +28,9 @@ if(array_key_exists('MAUTIC_DB_HOST', $_ENV)) {
     }
     else {
         $host = $_ENV['MAUTIC_DB_HOST'];
+        if(array_key_exists('MAUTIC_DB_PORT', $_ENV)) {
+            $parameters['db_port'] = $_ENV['MAUTIC_DB_PORT'];
+        }
     }
     $parameters['db_host'] = $host;
 }
@@ -31,16 +46,32 @@ if(array_key_exists('MAUTIC_DB_USER', $_ENV)) {
 if(array_key_exists('MAUTIC_DB_PASSWORD', $_ENV)) {
     $parameters['db_password'] = $_ENV['MAUTIC_DB_PASSWORD'];
 }
-if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
-    $proxies = explode(',', $_ENV['MAUTIC_TRUSTED_PROXIES']);
-    $parameters['trusted_proxies'] = $proxies;
-}
 
 if(array_key_exists('PHP_INI_DATE_TIMEZONE', $_ENV)) {
     $parameters['default_timezone'] = $_ENV['PHP_INI_DATE_TIMEZONE'];
 }
 
-$path     = '/var/www/html/app/config/local.php';
+if(array_key_exists('MAUTIC_ADMIN_EMAIL', $_ENV)) {
+    $parameters['admin_email'] = $_ENV['MAUTIC_ADMIN_EMAIL'];
+}
+if(array_key_exists('MAUTIC_ADMIN_PASSWORD', $_ENV)) {
+    $parameters['admin_password'] = $_ENV['MAUTIC_ADMIN_PASSWORD'];
+}
+
+// special case because this won't be propagated using the command-line installer
+if(array_key_exists('MAUTIC_TRUSTED_PROXIES', $_ENV)) {
+    $proxies = json_decode($_ENV['MAUTIC_TRUSTED_PROXIES']);
+    $parameters['trusted_proxies'] = $proxies;
+}
+
+// anything starting MAUTIC_CONFIG_ should be assumed to be a config variable,
+// so lowercased and shoved as-is into the parameters
+foreach($_ENV as $k=>$v) {
+	if( substr( $k, 0, 14 ) === 'MAUTIC_CONFIG_' )	{
+		$parameters[strtolower( substr( $k, 14 ) )] = $v;
+	}
+}
+
 $rendered = "<?php\n\$parameters = ".var_export($parameters, true).";\n";
 
 $status = file_put_contents($path, $rendered);

--- a/common/mautic.crontab
+++ b/common/mautic.crontab
@@ -1,20 +1,20 @@
 SHELL=/bin/bash
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
-8,23,38,52 * * * *     www-data   php /var/www/html/app/console mautic:segments:update > /var/log/cron.pipe 2>&1
-       */5 * * * *     www-data   php /var/www/html/app/console mautic:import > /var/log/cron.pipe 2>&1
-5,20,35,50 * * * *     www-data   php /var/www/html/app/console mautic:campaigns:rebuild > /var/log/cron.pipe 2>&1
-2,17,32,47 * * * *     www-data   php /var/www/html/app/console mautic:campaigns:trigger > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:messages:send > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:emails:send > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:email:fetch > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:social:monitoring > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:webhooks:process > /var/log/cron.pipe 2>&1
-0,15,30,45 * * * *     www-data   php /var/www/html/app/console mautic:broadcasts:send > /var/log/cron.pipe 2>&1
-         * 1 * * *     www-data   php /var/www/html/app/console mautic:maintenance:cleanup --days-old=365 > /var/log/cron.pipe 2>&1
-        0 4 15 * *     www-data   php /var/www/html/app/console mautic:iplookup:download > /var/log/cron.pipe 2>&1
-       */5 * * * *     www-data   php /var/www/html/app/console mautic:reports:scheduler > /var/log/cron.pipe 2>&1
-        0 5 10 * *     www-data   php /var/www/html/app/console mautic:unusedip:delete > /var/log/cron.pipe 2>&1
+8,23,38,52 * * * *     www-data   php /var/www/html/bin/console mautic:segments:update > /var/log/cron.pipe 2>&1
+       */5 * * * *     www-data   php /var/www/html/bin/console mautic:import > /var/log/cron.pipe 2>&1
+5,20,35,50 * * * *     www-data   php /var/www/html/bin/console mautic:campaigns:rebuild > /var/log/cron.pipe 2>&1
+2,17,32,47 * * * *     www-data   php /var/www/html/bin/console mautic:campaigns:trigger > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:messages:send > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:emails:send > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:email:fetch > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:social:monitoring > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:webhooks:process > /var/log/cron.pipe 2>&1
+0,15,30,45 * * * *     www-data   php /var/www/html/bin/console mautic:broadcasts:send > /var/log/cron.pipe 2>&1
+         * 1 * * *     www-data   php /var/www/html/bin/console mautic:maintenance:cleanup --days-old=365 > /var/log/cron.pipe 2>&1
+        0 4 15 * *     www-data   php /var/www/html/bin/console mautic:iplookup:download > /var/log/cron.pipe 2>&1
+       */5 * * * *     www-data   php /var/www/html/bin/console mautic:reports:scheduler > /var/log/cron.pipe 2>&1
+        0 5 10 * *     www-data   php /var/www/html/bin/console mautic:unusedip:delete > /var/log/cron.pipe 2>&1
 
 # download geoip db on start if it does not exist
-@reboot                www-data   [[ "$(ls -A /var/www/html/app/cache/ip_data 2>/dev/null)" ]] || php /var/www/html/app/console mautic:iplookup:download > /var/log/cron.pipe 2>&1
+@reboot                www-data   [[ "$(ls -A /var/www/html/bin/cache/ip_data 2>/dev/null)" ]] || php /var/www/html/bin mautic:iplookup:download > /var/log/cron.pipe 2>&1

--- a/example.env
+++ b/example.env
@@ -3,3 +3,5 @@ DOCKERHUB_USER=dockerhub_user
 GITHUB_TOKEN=ghp_************************************
 GITHUB_USER=github_user
 MAUTIC_VERSION=4.4.10
+PHP_VERSION=7.4.33
+PHP_SHA256=924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,36 +13,103 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
+# Define PHP version and SHA256 hash
 ARG PHP_VERSION="${PHP_VERSION:-7.4.33}"
 ARG PHP_SHA256="${PHP_SHA256:-924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927}"
 FROM "php:${PHP_VERSION}-fpm"
 
-LABEL vendor="redgnus"
-LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)"
-LABEL org.opencontainers.image.source="https://github.com/redtux/mautic"
+# Define Mautic version and SHA1 hash
+ENV MAUTIC_VERSION 4.4.10
+ENV MAUTIC_SHA1 8da80700b742d67dc7d952196adf0506b2ba0535
+
+# Set metadata labels
+LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)" \
+      org.opencontainers.image.description="Mautic ${MAUTIC_VERSION} · PHP ${PHP_VERSION} · FPM" \
+      org.opencontainers.image.source="https://github.com/redtux/mautic" \
+      vendor="redgnus"
+
+# Define environment variables
+ENV MAUTIC_RELEASE_URL=https://github.com/mautic/mautic/releases/download \
+    MAUTIC_RUN_CRON_JOBS=true \
+    MAUTIC_RUN_MIGRATIONS=false \
+    MAUTIC_DB_USER=root \
+    MAUTIC_DB_NAME=mautic \
+    MAUTIC_DB_PORT=3306 \
+    PHP_INI_DATE_TIMEZONE='UTC' \
+    PHP_MEMORY_LIMIT=512M \
+    PHP_MAX_UPLOAD=512M \
+    PHP_MAX_EXECUTION_TIME=300
+
+# Install system dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    ca-certificates \
+    cron \
+    curl \
+    imagemagick \
+    graphicsmagick \
+    libaprutil1-dev \
+    libc-client-dev \
+    libcurl4-gnutls-dev \
+    libfreetype6-dev \
+    libgif-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libjpeg62-turbo-dev \
+    libkrb5-dev \
+    libmagickwand-dev \
+    libmcrypt-dev \
+    libonig-dev \
+    libpng-dev \
+    libssl-dev \
+    libtiff-dev \
+    libwebp-dev \
+    libxpm-dev \
+    libxml2-dev \
+    libzip-dev \
+    sudo \
+    unzip \
+    wget \
+    zip \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm /etc/cron.daily/*
 
 # Install PHP extensions
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    cron \
-    git \
-    wget \
-    sudo \
-    libc-client-dev \
-    libicu-dev \
-    libkrb5-dev \
-    libmcrypt-dev \
-    libssl-dev \
-    libz-dev \
-    unzip \
-    zip \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm /etc/cron.daily/*
+RUN docker-php-ext-configure gd --with-freetype --with-jpeg \
+    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
+    && docker-php-ext-install \
+        bcmath \
+        curl \
+        exif \
+        gd \
+        imap \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        sockets \
+        zip \
+    && docker-php-ext-enable \
+        bcmath \
+        curl \
+        exif \
+        gd \
+        imap \
+        intl \
+        mbstring \
+        mysqli \
+        opcache \
+        pdo_mysql \
+        sockets \
+        zip
 
-RUN docker-php-ext-configure imap --with-imap --with-imap-ssl --with-kerberos \
-    && docker-php-ext-configure opcache --enable-opcache \
-    && docker-php-ext-install imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath \
-    && docker-php-ext-enable imap intl mbstring mcrypt mysqli pdo_mysql zip opcache bcmath
+# Copy necessary files
+COPY docker-entrypoint.sh /entrypoint.sh
+COPY makeconfig.php /makeconfig.php
+COPY makedb.php /makedb.php
+COPY mautic.crontab /etc/cron.d/mautic
 
 # Install composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
@@ -50,40 +117,18 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin -
 # Define Mautic volume to persist data
 VOLUME /var/www/html
 
-# Define Mautic version and expected SHA1 signature
-ENV MAUTIC_VERSION 4.4.10
-ENV MAUTIC_SHA1 8da80700b742d67dc7d952196adf0506b2ba0535
-
-# By default enable cron jobs
-ENV MAUTIC_RUN_CRON_JOBS true
-
-# Setting an root user for test
-ENV MAUTIC_DB_USER root
-ENV MAUTIC_DB_NAME mautic
-
-# Setting PHP properties
-ENV PHP_INI_DATE_TIMEZONE='UTC' \
-    PHP_MEMORY_LIMIT=512M \
-    PHP_MAX_UPLOAD=128M \
-    PHP_MAX_EXECUTION_TIME=300
-
-# Download package and extract to web volume
-RUN curl -o mautic.zip -SL https://github.com/mautic/mautic/releases/download/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip \
+# Download Mautic package and extract to web volume
+RUN curl -o mautic.zip -SL "${MAUTIC_RELEASE_URL}/${MAUTIC_VERSION}/${MAUTIC_VERSION}.zip" \
     && echo "$MAUTIC_SHA1 *mautic.zip" | sha1sum -c - \
     && mkdir /usr/src/mautic \
     && unzip mautic.zip -d /usr/src/mautic \
     && rm mautic.zip \
     && chown -R www-data:www-data /usr/src/mautic
 
-# Copy init scripts and custom .htaccess
-COPY docker-entrypoint.sh /entrypoint.sh
-COPY makeconfig.php /makeconfig.php
-COPY makedb.php /makedb.php
-COPY mautic.crontab /etc/cron.d/mautic
-RUN chmod 644 /etc/cron.d/mautic
+# Set file permissions
+RUN chmod 644 /etc/cron.d/mautic \
+ && chmod 755 /entrypoint.sh
 
-# Apply necessary permissions
-RUN ["chmod", "+x", "/entrypoint.sh"]
+# Define entrypoint and command
 ENTRYPOINT ["/entrypoint.sh"]
-
 CMD ["php-fpm"]

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,7 +13,8 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
-FROM php:7.1-fpm
+ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
+FROM "php:${PHP_VERSION}-fpm"
 
 LABEL vendor="redgnus"
 LABEL maintainer="Pablo Hörtner <redtux@pm.me> (@redtux)"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -14,6 +14,7 @@
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
 ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
+ARG PHP_SHA256="${PHP_SHA256:-bd7c0a9bd5433289ee01fd440af3715309faf583f75832b64fe169c100d52968}"
 FROM "php:${PHP_VERSION}-fpm"
 
 LABEL vendor="redgnus"

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -13,8 +13,8 @@
 # You can find the GPL 3.0 here:  https://www.gnu.org/licenses/gpl-3.0
 # The Mautic releases live here:  https://github.com/mautic/mautic/releases
 
-ARG PHP_VERSION="${PHP_VERSION:-7.1.33}"
-ARG PHP_SHA256="${PHP_SHA256:-bd7c0a9bd5433289ee01fd440af3715309faf583f75832b64fe169c100d52968}"
+ARG PHP_VERSION="${PHP_VERSION:-7.4.33}"
+ARG PHP_SHA256="${PHP_SHA256:-924846abf93bc613815c55dd3f5809377813ac62a9ec4eb3778675b82a27b927}"
 FROM "php:${PHP_VERSION}-fpm"
 
 LABEL vendor="redgnus"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -22,14 +22,7 @@ WORKDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
 cd "$WORKDIR"
 
 # Set environment variables
-ENV_FILE="${PWD}/.env"
-if [[ ! -f "${ENV_FILE}" ]]; then
-  cp -a example.env "${ENV_FILE}"
-fi
-
-# Source environment variables
-# shellcheck source=/dev/null
-source "${ENV_FILE}"
+set_env_vars
 
 # Log start of script
 clear

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -14,6 +14,16 @@
 IFS=$'\n\t'
 set -euo pipefail
 
+# Set environment variables
+set_env_vars() {
+  ENV_FILE="${PWD}/.env"
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    eval "echo \"$(envsubst < example.env)\"" > "${ENV_FILE}"
+  fi
+  # shellcheck source=/dev/null
+  source "${ENV_FILE}"
+}
+
 # Set log title color
 log_title() {
   local color='\033[1;35m'  # Purple

--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -22,14 +22,7 @@ WORKDIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")/.."
 cd "$WORKDIR"
 
 # Set environment variables
-ENV_FILE="${PWD}/.env"
-if [[ ! -f "${ENV_FILE}" ]]; then
-  cp -a example.env "${ENV_FILE}"
-fi
-
-# Source environment variables
-# shellcheck source=/dev/null
-source "${ENV_FILE}"
+set_env_vars
 
 if [ -z "${MAUTIC_VERSION:-}" ]; then
   latest_api_url="https://api.github.com/repos/mautic/mautic/releases/latest"


### PR DESCRIPTION
- Use dynamic PHP version in Dockerfile
- Set PHP SHA256 hash in Dockerfile
- Add PHP_VERSION and PHP_SHA256 to example.env
- Update build workflow
- Bump default PHP version from 7.1.33 to 7.4.33
- Update common scripts for use with Mautic 4
- Use function to set env vars in tools scripts
- Update Dockerfile for use with PHP 7.4